### PR TITLE
Standardize LLM client HTTP integrations

### DIFF
--- a/README
+++ b/README
@@ -1,19 +1,85 @@
-需要先设置环境变量VISION_MIND_PATH 用以指定程序需要的模型的路径
-比如设置为：F:\TestSth\JavaVisionMind\resource
-具体的路径为：F:\TestSth\JavaVisionMind\resource\lib\opencv\opencv_java490.dll
+# JavaVisionMind
 
+JavaVisionMind 是一组围绕计算机视觉与多模态能力构建的 Spring Boot 服务集合，涵盖目标检测、姿态识别、人脸识别、文搜图以及大模型推理等能力。项目采用多模块方式组织，可按需启停对应的服务。
 
-几个项目的介绍
-ffe 人脸识别
-llm 大模型调用
-reid 人员重识别
-tbir 文搜图
-yolo 目标识别和关键点检测等
+## 环境准备
 
+1. 安装 **JDK 17** 与 **Maven 3.8+**。
+2. 下载所需的模型与 OpenCV 运行时库，并通过环境变量 `VISION_MIND_PATH` 指定资源根目录。应用会基于该变量寻找模型与原生库，例如：
 
-JavaVisionMind.postman_collection.json 是postman的测试用例导出
+   ```bash
+   # Windows PowerShell
+   setx VISION_MIND_PATH "F:\\TestSth\\JavaVisionMind\\resource"
 
-1、使用vision-mind-llm的时候需要先配置好大模型的地址，支持ollma或者openai的接口模式
-2、vision-mind-llm 后续也会支持llama的服务调用，流模式等 TODO
-3、目前XXXX 都是用lunce实现的持久化向量存储，后续会增加内存的向量存储，重启清空 TODO
-4、yolo支持视频解析 TODO
+   # Linux / macOS shell
+   export VISION_MIND_PATH=/opt/JavaVisionMind/resource
+   ```
+
+   典型的目录结构如下：
+
+   ```text
+   ${VISION_MIND_PATH}
+   └── lib
+       └── opencv
+           ├── opencv_java490.dll   # Windows 动态库
+           └── libopencv_java490.so # Linux 动态库
+   ```
+
+3. 根据操作系统确认 `opencv_java490` 动态库可被 Java 加载（已在核心服务中根据系统类型自动选择 `.dll` 或 `.so` 文件）。
+
+## 模块简介
+
+| 模块 | 说明 |
+| --- | --- |
+| `vision-mind-yolo-core` | 封装 YOLOv11/FAST-SAM 推理逻辑，提供图片检测、姿态识别、分割等能力。 |
+| `vision-mind-yolo-app` | 基于 Spring Boot 的 YOLO REST 服务入口。 |
+| `vision-mind-ffe-app` | 人脸检测与特征提取相关服务。 |
+| `vision-mind-reid-app` | 人员重识别服务，实现跨镜追踪。 |
+| `vision-mind-tbir-app` | 文本检索图片（Text-Based Image Retrieval）能力。 |
+| `vision-mind-llm-core` | 面向 OpenAI / Ollama 的大语言模型接入。 |
+| `vision-mind-common` | DTO、工具类等公共依赖。 |
+| `vision-mind-test-sth` | 开发阶段的验证与示例代码。 |
+
+## 快速启动
+
+以 YOLO 服务为例：
+
+```bash
+mvn -pl vision-mind-yolo-app spring-boot:run
+```
+
+大模型服务入口位于 `vision-mind-llm-core` 模块，可通过以下方式启动：
+
+```bash
+mvn -pl vision-mind-llm-core spring-boot:run
+```
+
+服务默认端口与上下文路径可在各模块的 `application.properties` 中调整。
+
+## 大模型配置
+
+- 在 `vision-mind-llm-core/src/main/resources/application.properties` 中配置对接信息。
+- 同时填写 OpenAI 与 Ollama 时，会优先调用 OpenAI 配置；仅填写 Ollama 时则回退至本地服务。
+- 示例：
+
+  ```properties
+  # 任选一个大模型服务进行配置
+  ollama.base-url=http://127.0.0.1:11434
+  ollama.chat.options.model=gemma3:1b
+
+  openai.base-url=https://api.openai.com/v1/chat/completions
+  openai.api-key=YOUR_API_KEY
+  openai.chat.options.model=gpt-4o-mini
+  ```
+
+## 调试与测试
+
+仓库根目录提供 `JavaVisionMind.postman_collection.json`，可导入 Postman/Apifox 进行接口调试。
+
+## Roadmap
+
+- 支持基于 LLaMA 的服务部署与流式输出。
+- 向量存储在当前 Lucene 实现基础上，计划补充内存态存储方案。
+- YOLO 视频流解析能力（`vision-mind-yolo-core` 中保留实现草稿）。
+
+欢迎提交 Issue 或 PR 进一步完善项目。

--- a/vision-mind-llm-core/src/main/java/com/yuqiangdede/llm/client/OllamaClient.java
+++ b/vision-mind-llm-core/src/main/java/com/yuqiangdede/llm/client/OllamaClient.java
@@ -2,56 +2,63 @@ package com.yuqiangdede.llm.client;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.stereotype.Service;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.yuqiangdede.llm.client.support.HttpJsonClient;
 
-import java.io.*;
-import java.net.HttpURLConnection;
+import java.io.IOException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Objects;
 
-@Service
-public class OllamaClient {
+/**
+ * 面向 Ollama 本地服务的对话客户端。
+ */
+public final class OllamaClient {
 
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String RESPONSE_FIELD = "response";
+    private static final String GENERATE_PATH = "/api/generate";
 
+    private OllamaClient() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    /**
+     * 通过 Ollama 本地服务进行对话推理。
+     *
+     * @param ollamaBaseUrl Ollama 服务地址，例如 http://127.0.0.1:11434
+     * @param ollamaModel   待调用的模型名称
+     * @param prompt        用户输入的提示词
+     */
     public static String chat(String ollamaBaseUrl, String ollamaModel, String prompt) throws IOException {
-        String s = sendPrompt(ollamaBaseUrl, ollamaModel, prompt);
-        ObjectMapper mapper = new ObjectMapper();
-        JsonNode root = mapper.readTree(s);
-        String response = root.get("response").asText();
-        return response.trim();
+        Objects.requireNonNull(ollamaBaseUrl, "ollamaBaseUrl");
+        Objects.requireNonNull(ollamaModel, "ollamaModel");
+        Objects.requireNonNull(prompt, "prompt");
+
+        String responseJson = sendPrompt(ollamaBaseUrl, ollamaModel, prompt);
+        JsonNode root = MAPPER.readTree(responseJson);
+        JsonNode responseNode = root.get(RESPONSE_FIELD);
+        if (responseNode == null || responseNode.isNull()) {
+            throw new IOException("Ollama 响应中缺少 response 字段");
+        }
+        return responseNode.asText().trim();
     }
 
-    public static String sendPrompt(String ollamaBaseUrl, String ollamaModel, String prompt) throws IOException {
-        URL url = new URL(ollamaBaseUrl + "/api/generate");
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    private static String sendPrompt(String ollamaBaseUrl, String ollamaModel, String prompt) throws IOException {
+        ObjectNode body = MAPPER.createObjectNode();
+        body.put("model", ollamaModel);
+        body.put("prompt", prompt);
+        body.put("stream", false);
 
-        conn.setRequestMethod("POST");
-        conn.setRequestProperty("Content-Type", "application/json");
-        conn.setDoOutput(true);
-
-        // 构建请求体
-        String body = String.format(
-                "{\"model\":\"%s\",\"prompt\":\"%s\",\"stream\":false}",
-                ollamaModel, prompt.replace("\"", "\\\"")
-        );
-
-        try (OutputStream os = conn.getOutputStream()) {
-            byte[] input = body.getBytes(StandardCharsets.UTF_8);
-            os.write(input, 0, input.length);
-        }
-
-        // 读取返回
-        try (BufferedReader br = new BufferedReader(
-                new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
-
-            StringBuilder response = new StringBuilder();
-            String line;
-            while ((line = br.readLine()) != null) {
-                response.append(line.trim());
-            }
-            return response.toString();
-        }
+        URL url = new URL(normalizeBaseUrl(ollamaBaseUrl) + GENERATE_PATH);
+        return HttpJsonClient.post(url, Collections.emptyMap(), body);
     }
 
-
+    private static String normalizeBaseUrl(String baseUrl) {
+        String trimmed = baseUrl.trim();
+        if (trimmed.endsWith("/")) {
+            return trimmed.substring(0, trimmed.length() - 1);
+        }
+        return trimmed;
+    }
 }

--- a/vision-mind-llm-core/src/main/java/com/yuqiangdede/llm/client/OpenAIClient.java
+++ b/vision-mind-llm-core/src/main/java/com/yuqiangdede/llm/client/OpenAIClient.java
@@ -2,65 +2,72 @@ package com.yuqiangdede.llm.client;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.yuqiangdede.llm.client.support.HttpJsonClient;
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.*;
-import java.net.HttpURLConnection;
+import java.io.IOException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
 
 @Slf4j
-public class OpenAIClient {
+public final class OpenAIClient {
 
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String HEADER_AUTHORIZATION = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
 
-    public static String chat(String openaiBaseUrl, String openaiKey, String openaiModel, String prompt) throws IOException {
-        String responseJson = sendPrompt(openaiBaseUrl, openaiKey, openaiModel, prompt);
-        ObjectMapper mapper = new ObjectMapper();
-        JsonNode root = mapper.readTree(responseJson);
-        String content = root.get("choices").get(0).get("message").get("content").asText();
-        return content.trim();
+    private OpenAIClient() {
+        throw new UnsupportedOperationException("Utility class");
     }
 
-    public static String sendPrompt(String openaiBaseUrl, String openaiKey, String openaiModel, String prompt) throws IOException {
-        URL url = new URL(openaiBaseUrl);
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    /**
+     * 调用 OpenAI Chat Completions 接口并返回纯文本回答。
+     *
+     * @param openaiBaseUrl OpenAI 接口地址
+     * @param openaiKey     OpenAI API Key
+     * @param openaiModel   目标模型名称
+     * @param prompt        用户输入的提示词
+     */
+    public static String chat(String openaiBaseUrl, String openaiKey, String openaiModel, String prompt) throws IOException {
+        Objects.requireNonNull(openaiBaseUrl, "openaiBaseUrl");
+        Objects.requireNonNull(openaiKey, "openaiKey");
+        Objects.requireNonNull(openaiModel, "openaiModel");
+        Objects.requireNonNull(prompt, "prompt");
 
-        conn.setRequestMethod("POST");
-        conn.setRequestProperty("Content-Type", "application/json");
-        conn.setRequestProperty("Authorization", "Bearer " + openaiKey);
-        conn.setDoOutput(true);
+        String responseJson = sendPrompt(openaiBaseUrl, openaiKey, openaiModel, prompt);
+        JsonNode root = MAPPER.readTree(responseJson);
 
-        // 构建请求体
-        String body = String.format(
-                "{\n" +
-                        "  \"model\": \"%s\",\n" +
-                        "  \"messages\": [\n" +
-                        "    {\"role\": \"user\", \"content\": \"%s\"}\n" +
-                        "  ]\n" +
-                        "}", openaiModel, prompt.replace("\"", "\\\"")
-        );
+        JsonNode contentNode = root.path("choices").path(0).path("message").path("content");
+        if (contentNode.isMissingNode() || contentNode.isNull()) {
+            throw new IOException("OpenAI 响应中缺少 message.content 字段");
+        }
+        return contentNode.asText().trim();
+    }
 
-        log.debug("OpenAIClient POST to: {}", openaiBaseUrl);
+    private static String sendPrompt(String openaiBaseUrl, String openaiKey, String openaiModel, String prompt) throws IOException {
+        ObjectNode body = MAPPER.createObjectNode();
+        body.put("model", openaiModel);
+
+        ArrayNode messages = body.putArray("messages");
+        ObjectNode messageNode = messages.addObject();
+        messageNode.put("role", "user");
+        messageNode.put("content", prompt);
+
+        Map<String, String> headers = Collections.singletonMap(HEADER_AUTHORIZATION, BEARER_PREFIX + openaiKey);
+
+        String normalizedUrl = openaiBaseUrl.trim();
+
+        log.debug("OpenAIClient POST to: {}", normalizedUrl);
         log.debug("OpenAIClient Body: {}", body);
 
-        try (OutputStream os = conn.getOutputStream()) {
-            byte[] input = body.getBytes(StandardCharsets.UTF_8);
-            os.write(input, 0, input.length);
-        }
+        URL url = new URL(normalizedUrl);
+        String response = HttpJsonClient.post(url, headers, body);
 
-        // 读取返回
-        try (BufferedReader br = new BufferedReader(
-                new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
-
-            StringBuilder response = new StringBuilder();
-            String line;
-            while ((line = br.readLine()) != null) {
-                log.debug("OpenAIClient Response: {}", line);
-                response.append(line.trim());
-            }
-            return response.toString();
-        }
+        log.debug("OpenAIClient Response: {}", response);
+        return response;
     }
-
-
 }

--- a/vision-mind-llm-core/src/main/java/com/yuqiangdede/llm/client/support/HttpJsonClient.java
+++ b/vision-mind-llm-core/src/main/java/com/yuqiangdede/llm/client/support/HttpJsonClient.java
@@ -1,0 +1,82 @@
+package com.yuqiangdede.llm.client.support;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * 面向大模型集成的轻量级 JSON HTTP 工具类。
+ */
+public final class HttpJsonClient {
+
+    private static final int DEFAULT_TIMEOUT_MS = 30_000;
+    private static final String METHOD_POST = "POST";
+    private static final String HEADER_CONTENT_TYPE = "Content-Type";
+    private static final String CONTENT_TYPE_JSON = "application/json";
+
+    private HttpJsonClient() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static String post(URL url, Map<String, String> headers, JsonNode body) throws IOException {
+        Objects.requireNonNull(url, "url");
+        Objects.requireNonNull(body, "body");
+
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod(METHOD_POST);
+        connection.setDoOutput(true);
+        connection.setConnectTimeout(DEFAULT_TIMEOUT_MS);
+        connection.setReadTimeout(DEFAULT_TIMEOUT_MS);
+        connection.setRequestProperty(HEADER_CONTENT_TYPE, CONTENT_TYPE_JSON);
+
+        if (headers != null) {
+            for (Map.Entry<String, String> entry : headers.entrySet()) {
+                if (entry.getKey() != null && entry.getValue() != null) {
+                    connection.setRequestProperty(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+
+        byte[] payload = body.toString().getBytes(StandardCharsets.UTF_8);
+        try (OutputStream outputStream = connection.getOutputStream()) {
+            outputStream.write(payload);
+        }
+
+        int status = connection.getResponseCode();
+        InputStream responseStream = status >= HttpURLConnection.HTTP_OK && status < HttpURLConnection.HTTP_MULT_CHOICE
+                ? connection.getInputStream()
+                : connection.getErrorStream();
+
+        if (responseStream == null) {
+            connection.disconnect();
+            throw new IOException("未能从 " + url + " 读取到响应内容");
+        }
+
+        String responseBody;
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(responseStream, StandardCharsets.UTF_8))) {
+            StringBuilder builder = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                builder.append(line);
+            }
+            responseBody = builder.toString();
+        } finally {
+            connection.disconnect();
+        }
+
+        if (status < HttpURLConnection.HTTP_OK || status >= HttpURLConnection.HTTP_MULT_CHOICE) {
+            throw new IOException(String.format("调用 %s 失败，HTTP 状态码：%d，响应：%s", url, status, responseBody));
+        }
+
+        return responseBody;
+    }
+}

--- a/vision-mind-llm-core/src/main/java/com/yuqiangdede/llm/service/LLMService.java
+++ b/vision-mind-llm-core/src/main/java/com/yuqiangdede/llm/service/LLMService.java
@@ -5,6 +5,7 @@ import com.yuqiangdede.llm.client.OpenAIClient;
 import com.yuqiangdede.llm.config.Config;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 
@@ -18,26 +19,35 @@ public class LLMService {
         this.config = config;
     }
 
-    private boolean isNotBlank(String value) {
-        return value != null && !value.trim().isEmpty();
-    }
-
     public String chat(String message) throws IOException {
-        if (isNotBlank(config.getOpenaiBaseUrl()) &&
-                isNotBlank(config.getOpenaiKey()) &&
-                isNotBlank(config.getOpenaiModel())) {
+        if (!StringUtils.hasText(message)) {
+            throw new IllegalArgumentException("对话内容不能为空");
+        }
+
+        // 聊天流程遵循“优先外部云端、其次本地”原则：
+        // 1. 只要配置了 OpenAI 的地址、密钥和模型，就调用云端服务。
+        if (isConfigured(config.getOpenaiBaseUrl()) &&
+                isConfigured(config.getOpenaiKey()) &&
+                isConfigured(config.getOpenaiModel())) {
             return OpenAIClient.chat(config.getOpenaiBaseUrl(), config.getOpenaiKey(), config.getOpenaiModel(), message);
         }
 
-        if (isNotBlank(config.getOllamaBaseUrl()) &&
-                isNotBlank(config.getOllamaModel())) {
+        // 2. 未配置 OpenAI 时回退到 Ollama，本地推理无需 API Key。
+        if (isConfigured(config.getOllamaBaseUrl()) &&
+                isConfigured(config.getOllamaModel())) {
             return OllamaClient.chat(config.getOllamaBaseUrl(), config.getOllamaModel(), message);
         }
 
+        // 3. 两者都未配置时视为环境未准备好，直接抛出异常提醒使用者。
         throw new IllegalStateException("未配置 OpenAI 或 Ollama，无法对话");
     }
 
     public String chatWithImg(String message, String img) {
+        // TODO: 预留图文多模态调用能力，后续接入具备图像理解能力的模型再补充实现。
         return null;
+    }
+
+    private boolean isConfigured(String value) {
+        return StringUtils.hasText(value);
     }
 }


### PR DESCRIPTION
## Summary
- extract a reusable HttpJsonClient helper to send JSON POST requests with timeouts and error handling
- refactor the Ollama and OpenAI clients to build requests with ObjectMapper, reuse the helper, and validate required fields
- tighten LLMService validation by checking chat input and using StringUtils for configuration checks

## Testing
- `mvn -pl vision-mind-llm-core test` *(fails: unable to download Spring Boot parent POM because the Maven Central network endpoint is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f2b0d8b0832bbae5d71bdc3a8f74